### PR TITLE
Patch 3.0.6

### DIFF
--- a/bot/modules/Tex/resources/default_preamble.tex
+++ b/bot/modules/Tex/resources/default_preamble.tex
@@ -1,9 +1,6 @@
 % Always typeset math in display style
 \everymath{\displaystyle}
 
-% Use a larger font size
-\usepackage[fontsize=14pt]{scrextend}
-
 % Standard mathematical typesetting packages
 \usepackage[T1]{fontenc}
 \usepackage{amsthm, amsmath, amssymb}

--- a/bot/modules/Tex/tex_cmd.py
+++ b/bot/modules/Tex/tex_cmd.py
@@ -102,6 +102,10 @@ async def cmd_tex(ctx, flags):
     flags = {}
     parse_mode = ParseMode.DOCUMENT
 
+    # Set parse mode to gather if alwaysmath is enabled
+    if luser.alwaysmath == 1:
+        parse_mode = ParseMode.GATHER
+
     lalias = ctx.alias.lower()
     if lalias in [',', 'mtex']:
         parse_mode = ParseMode.GATHER
@@ -116,6 +120,14 @@ async def cmd_tex(ctx, flags):
 
     # Clean mentions
     content = ctx.clean_arg_str()
+
+    # Strip spoiler characters from input if texsp is used
+    try:
+        if flags["spoiler"]:
+            if content.count("||") >= 2:
+                content = content.replace("||", "")
+    except KeyError:
+        pass
 
     # Parse source
     source = LatexContext.parse_content(content, parse_mode)


### PR DESCRIPTION
## Changes
- Spoiler characters (`||`) are now stripped from message content when using the `texsp` alias.
- The spoiler characters will only be stripped if there are at least two sets of them in the message.

## Fixes
- Update all Info commands to use Discord's own timestamp formatting.