### PR TITLE
New output and image conversion routine

### DIFF
--- a/bot/modules/Tex/core/LatexContext.py
+++ b/bot/modules/Tex/core/LatexContext.py
@@ -416,9 +416,9 @@ class LatexContext:
             if mode == ParseMode.DOCUMENT:
                 source = "\n\n".join(blocks)
             elif mode == ParseMode.GATHER:
-                source = "\n".join(["\\begin{{gather*}}\n{}\n\\end{{gather*}}".format(block) for block in blocks])
+                source = "\n".join(["$\\begin{{gathered}}\n{}\n\\end{{gathered}}$".format(block) for block in blocks])
             elif mode == ParseMode.ALIGN:
-                source = "\n".join(["\\begin{{align*}}\n{}\n\\end{{align*}}".format(block) for block in blocks])
+                source = "\n".join(["$\\begin{{aligned}}\n{}\n\\end{{aligned}}$".format(block) for block in blocks])
             elif mode == ParseMode.TIKZ:
                 source = "\n".join(["\\begin{{tikzpicture}}\n{}\n\\end{{tikzpicture}}".format(block) for block in blocks])
             else:

--- a/bot/modules/Tex/core/LatexUserSetting.py
+++ b/bot/modules/Tex/core/LatexUserSetting.py
@@ -187,8 +187,8 @@ class colour(LatexUserSetting, String):
         "darkgrey": "Dark grey background, with white text.",
         "dark": "Dark background, with white text.",
         "black": "Pure black background, with white text.",
-        "transparent": "Transparent background, with white text. (May cause issues)",
-        "trans_black": "Transparent background, with black text. (May cause issues)"
+        "transparent": "Transparent background, with white text.",
+        "trans_black": "Transparent background, with black text."
     }
     tabled_colourschemes = prop_tabulate(list(colourschemes.keys()), list(colourschemes.values()))
 
@@ -241,7 +241,7 @@ class alwaysmath(LatexUserSetting, Boolean):
         if not data:
             return "The `tex` command will now render in paragraph mode, as usual."
         else:
-            return "The `tex` command will now render in maths mode, i.e., in a `gather*` environment."
+            return "The `tex` command will now render in maths mode, i.e., in a `gathered` environment."
 
 
 class alwayswide(LatexUserSetting, Boolean):

--- a/bot/modules/Tex/core/tex_compile.py
+++ b/bot/modules/Tex/core/tex_compile.py
@@ -22,7 +22,7 @@ def gencolour(bgcolour, textcolour):
     """
     Build the class options for the provided colourscheme
     """
-    return r"bgcolor={}, textcolor={}".format(bgcolour, textcolour)
+    return r", bgcolor={}, textcolor={}".format(bgcolour, textcolour)
 
 
 # Dictionary of valid colours and the associated transformation commands
@@ -57,7 +57,7 @@ header = "\\IfFileExists{eggs.sty}{\\usepackage{eggs}}{}\
 """
 
 # The format of the source to compile
-to_compile = "\\documentclass[12pt, {colour}{alwayswide}]{{texit}}\
+to_compile = "\\documentclass[12pt{colour}{alwayswide}]{{texit}}\
     \n{header}\
     \n{preamble}\
     \n\\begin{{document}}\
@@ -89,7 +89,7 @@ async def makeTeX(ctx, source, targetid, preamble=default_preamble, colour="defa
 
     with open(fn, 'w') as work:
         work.write(to_compile.format(colour=colourschemes[colour] or "",
-                                     alwayswide="" if pad else ", alwayswide",
+                                     alwayswide=", minpagewidth=110pt" if pad else "",
                                      header=header, preamble=preamble, source=source))
         work.close()
 

--- a/bot/modules/Tex/core/tex_compile.py
+++ b/bot/modules/Tex/core/tex_compile.py
@@ -57,7 +57,7 @@ header = "\\IfFileExists{eggs.sty}{\\usepackage{eggs}}{}\
 """
 
 # The format of the source to compile
-to_compile = "\\documentclass[{colour}{alwayswide}]{{texit}}\
+to_compile = "\\documentclass[12pt, {colour}{alwayswide}]{{texit}}\
     \n{header}\
     \n{preamble}\
     \n\\begin{{document}}\

--- a/bot/modules/Tex/core/tex_compile.py
+++ b/bot/modules/Tex/core/tex_compile.py
@@ -57,7 +57,7 @@ header = "\\IfFileExists{eggs.sty}{\\usepackage{eggs}}{}\
 """
 
 # The format of the source to compile
-to_compile = "\\documentclass[12pt{colour}{alwayswide}]{{texit}}\
+to_compile = "\\documentclass[12pt, singlepage{colour}{alwayswide}]{{texit}}\
     \n{header}\
     \n{preamble}\
     \n\\begin{{document}}\

--- a/bot/modules/Tex/core/tex_compile.py
+++ b/bot/modules/Tex/core/tex_compile.py
@@ -20,9 +20,9 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 def gencolour(bgcolour, textcolour):
     """
-    Build the colour definition commands for the provided colourscheme
+    Build the class options for the provided colourscheme
     """
-    return r"\def\texit@bgcolor{{{}}} \def\texit@textcolor{{{}}}".format(bgcolour, textcolour)
+    return r"bgcolor={}, textcolor={}".format(bgcolour, textcolour)
 
 
 # Dictionary of valid colours and the associated transformation commands
@@ -46,23 +46,18 @@ colourschemes["default"] = colourschemes["grey"]
 
 
 # Header for every LaTeX source file
-header = "\\documentclass{texit}\
-    \n\\IfFileExists{eggs.sty}{\\usepackage{eggs}}{}\
+header = "\\IfFileExists{eggs.sty}{\\usepackage{eggs}}{}\
     \n\\nonstopmode"
 
 """
 # Alternative header to support discord emoji, but not other unicode
-header = "\\documentclass[preview, border=20pt, 12pt]{standalone}\
-    \n\\IfFileExists{eggs.sty}{\\usepackage{eggs}}{}\
+header = "\\IfFileExists{eggs.sty}{\\usepackage{eggs}}{}\
     \n\\usepackage{discord-emoji}
     \n\\nonstopmode"
 """
 
 # The format of the source to compile
-to_compile = "\\makeatletter\
-    \n{colour}\
-    \n{alwayswide}\
-    \n\\makeatother\
+to_compile = "\\documentclass[{colour}{alwayswide}]{{texit}}\
     \n{header}\
     \n{preamble}\
     \n\\begin{{document}}\
@@ -94,7 +89,7 @@ async def makeTeX(ctx, source, targetid, preamble=default_preamble, colour="defa
 
     with open(fn, 'w') as work:
         work.write(to_compile.format(colour=colourschemes[colour] or "",
-                                     alwayswide="\\def\\texit@alwayswide{0}" if pad else "\\def\\texit@alwayswide{1}",
+                                     alwayswide="" if pad else ", alwayswide",
                                      header=header, preamble=preamble, source=source))
         work.close()
 

--- a/bot/modules/Tex/resources/texcompile.sh
+++ b/bot/modules/Tex/resources/texcompile.sh
@@ -23,7 +23,7 @@ then
   exit 1
 fi
 
-timeout 20 convert -density 700 -quality 75 -depth 8 -trim +repage $1.pdf -colorspace sRGB $1.png;
+timeout 20 gs -q -r1800 -sDEVICE=pngalpha -dBATCH -dNOPAUSE -dDownScaleFactor=3 -sOutputFile=$1.png $1.pdf
 if [ $? -eq 124 ];
 then
  echo "Image processing timed out!";

--- a/bot/modules/Tex/resources/texcompile.sh
+++ b/bot/modules/Tex/resources/texcompile.sh
@@ -23,7 +23,7 @@ then
   exit 1
 fi
 
-timeout 20 gs -q -r1800 -sDEVICE=pngalpha -dBATCH -dNOPAUSE -dDownScaleFactor=3 -sOutputFile=$1.png $1.pdf
+timeout 20 gs -q -dSAFER -dBATCH -dNOPAUSE -sDEVICE=pngalpha -r1800 -dDownScaleFactor=3 -sOutputFile=$1.png $1.pdf
 if [ $? -eq 124 ];
 then
  echo "Image processing timed out!";

--- a/bot/modules/Tex/tex_cmd.py
+++ b/bot/modules/Tex/tex_cmd.py
@@ -34,8 +34,8 @@ async def cmd_tex(ctx, flags):
             is generally not required.
     Aliases::
         tex: Code is compiled in the default `document` environment.
-        , or mtex: Code is rendered in math mode, in a `gather*` environment.
-        align: Code is rendered in math mode, aligned in an `align*` environment.
+        , or mtex: Code is rendered in math mode, in a `gathered` environment.
+        align: Code is rendered in math mode, aligned in an `aligned` environment.
         texsp: Same as `tex`, but ||spoiler|| the output image.
         texw: Don't pad the output (with transparent pixels) after compilation.
         tikz: Code is rendered in a `tikzpicture` environment.


### PR DESCRIPTION
This patch implements the new output routine as described in [my writeup at #kapa-test](https://discord.com/channels/411477843969703936/1377230616176889856/1377360909118476318).

The [class file `texit.cls`](https://gist.github.com/plante3/781135d162aaee444382b11ebd215673) will have to be installed to texlive manually. My recommended procedure for installation is to put it under `texlive/20XX/texmf-dist/tex/` and run `texhash` on that directory.