### PR TITLE
Fix discord link display issue for ,ctan command in latexutil_cmds.py

### DIFF
--- a/bot/modules/Tex/latexutil_cmds.py
+++ b/bot/modules/Tex/latexutil_cmds.py
@@ -201,10 +201,13 @@ def search_n_parse(soup: BeautifulSoup):
             for link in links:
                 if tds[0].text == "Documentation":
                     link.insert_after(", ")
-                md_link = "[{}]({})".format(
-                    link.text,
-                    urllib.parse.urljoin(ctan_url, link.attrs["href"])
-                )
+                if link.text == urllib.parse.urljoin(ctan_url, link.attrs["href"]):
+                    md_link = link.text
+                else:
+                    md_link = "[{}]({})".format(
+                        link.text,
+                        urllib.parse.urljoin(ctan_url, link.attrs["href"])
+                    )
                 tds[1].a.replace_with(md_link)
 
         prop_list.append(tds[0].text)
@@ -313,10 +316,13 @@ async def cmd_ctan(ctx):
 
         md_links = []
         for url in urls:
-            md_link = "[{}]({})".format(
-                url.text,
-                urllib.parse.urljoin(ctan_url,url.attrs["href"])
-            )
+            if link.text == urllib.parse.urljoin(ctan_url, link.attrs["href"]):
+                md_link = link.text
+            else:
+                md_link = "[{}]({})".format(
+                    link.text,
+                    urllib.parse.urljoin(ctan_url, link.attrs["href"])
+                )
             md_links.append(md_link)
         field_value = "\n".join(md_links)
         embed.add_field(name=stats, value=field_value)


### PR DESCRIPTION
When retrieving links from CTAN the link text if unspecified will be the link itself, meaning the markdown will be of the form `[https://link...](https://link...)`. Unfortunately Discord does not allow the string “`https://`” in the link text (presumably to prevent link spoofing), so this will display incorrectly. The fix is simple: just print the link by itself when the link text and link coincide.