### PR TITLE
Fix incorrect variable names being used in ctan command

### DIFF
--- a/bot/modules/Tex/core/LatexContext.py
+++ b/bot/modules/Tex/core/LatexContext.py
@@ -161,7 +161,7 @@ class LatexContext:
             else:
                 raise ValueError("Unknown LatexUser namestyle `{}`.".format(self.luser.namestyle))
 
-            name = "{}\n".format(
+            name = "**{}**\n".format(
                 discord.utils.escape_mentions(discord.utils.escape_markdown(raw_name))
             )
         return name

--- a/bot/modules/Tex/latexutil_cmds.py
+++ b/bot/modules/Tex/latexutil_cmds.py
@@ -316,12 +316,12 @@ async def cmd_ctan(ctx):
 
         md_links = []
         for url in urls:
-            if link.text == urllib.parse.urljoin(ctan_url, link.attrs["href"]):
-                md_link = link.text
+            if url.text == urllib.parse.urljoin(ctan_url, url.attrs["href"]):
+                md_link = url.text
             else:
                 md_link = "[{}]({})".format(
-                    link.text,
-                    urllib.parse.urljoin(ctan_url, link.attrs["href"])
+                    url.text,
+                    urllib.parse.urljoin(ctan_url, url.attrs["href"])
                 )
             md_links.append(md_link)
         field_value = "\n".join(md_links)


### PR DESCRIPTION
- Fixed variable names being incorrect under the `ctans` alias and therefore breaking the command.
- Re-added the bolding in the LatexContext name heading.