### PR TITLE
Add 'wolfram' as alias to query command (fixes #21)

### DIFF
--- a/bot/modules/Maths/wolf_cmd.py
+++ b/bot/modules/Maths/wolf_cmd.py
@@ -243,7 +243,7 @@ def triage_pods(pod_list):
 @module.cmd("query",
             desc="Query the [Wolfram Alpha computation engine]({}).".format(WEB),
             flags=["text"],
-            aliases=["ask", "wolf", "w", "?w"])
+            aliases=["ask", "wolf", "wolfram", "w", "?w"])
 async def cmd_query(ctx, flags):
     """
     Usage``:


### PR DESCRIPTION
Closes #21

Adds `wolfram` as an alias for the `query` command.

Previously, users typing `~wolfram <query>` would unintentionally
match the existing `wolf` alias, causing the bot to treat the leading
`ram` as part of the query and producing nonsensical results.

The alias is added next to `wolf` in the alias list to keep related
aliases grouped together.