### PR TITLE
Catch HTTPException when deleting selector messages (fixes #20)

### DIFF
--- a/bot/utils/interactive.py
+++ b/bot/utils/interactive.py
@@ -122,6 +122,8 @@ async def selector(ctx, header, select_from, timeout=120, max_len=20, allow_sing
         pass
     except discord.Forbidden:
         pass
+    except discord.HTTPException:
+        pass
 
     # Handle user cancellation
     if result_msg.content in ['c', 'C']:
@@ -209,6 +211,8 @@ async def multi_selector(ctx, header, select_from, timeout=120, max_len=20, allo
     except discord.NotFound:
         pass
     except discord.Forbidden:
+        pass
+    except discord.HTTPException:
         pass
 
     # Handle user cancellation


### PR DESCRIPTION
Closes #20

When `selector` or `multi_selector` are triggered in rapid succession
(e.g. spamming commands that rely on the listening utils), Discord can
rate-limit the bot while it attempts to delete the prompt and response
messages, raising `discord.HTTPException` (HTTP 429) — which was not
handled and bubbled up as an ungraceful traceback.

Adds a third `except discord.HTTPException: pass` clause after the
existing `NotFound` / `Forbidden` handlers in both `selector` and
`multi_selector`. Placing it last preserves the existing explicit
handling for 403/404 (which are themselves subclasses of
`HTTPException`) while now also silently absorbing 429s and any other
transient API error during cleanup.

No behaviour change in the success case; only the failure mode is
improved.