### PR TITLE
Add gradient role support for command roleinfo

### DIFF
--- a/bot/modules/Info/info_cmds.py
+++ b/bot/modules/Info/info_cmds.py
@@ -82,6 +82,17 @@ async def cmd_roleinfo(ctx: Context):
     if not role:
         return
 
+    # Handle roles with gradients
+    if role.secondary_colour:
+        colour_prop = "Gradient"
+        if role.tertiary_color:
+            colour_value = str(role.colour) + "–" + str(role.secondary_colour) + "–" + str(role.tertiary_colour)
+        else:
+            colour_value = str(role.colour) + "–" + str(role.secondary_colour)
+    else:
+        colour_prop = "Colour"
+        colour_value = str(role.colour)
+
     # Prepare the role properties
     colour = role.colour if role.colour.value else discord.Colour.light_grey()
     num_users = len(role.members)
@@ -90,8 +101,8 @@ async def cmd_roleinfo(ctx: Context):
     mentionable = "Yes" if role.mentionable else "No"
 
     # Build the property/value table
-    prop_list = ["Colour", "Hoisted", "Mentionable", "Number of members", "Created at"]
-    value_list = [str(role.colour), hoisted, mentionable, num_users, created_ago]
+    prop_list = [colour_prop, "Hoisted", "Mentionable", "Number of members", "Created at"]
+    value_list = [colour_value, hoisted, mentionable, num_users, created_ago]
     desc = prop_tabulate(prop_list, value_list)
 
     # Build the hierarchy graph

--- a/bot/modules/Info/info_cmds.py
+++ b/bot/modules/Info/info_cmds.py
@@ -82,8 +82,8 @@ async def cmd_roleinfo(ctx: Context):
     if not role:
         return
 
-    # Handle roles with gradients
-    if role.secondary_colour:
+    # Handle roles with gradients, also check if server is boosted to prevent showing gradient after loosing boosts
+    if "ENHANCED_ROLE_COLORS" in ctx.guild.features and role.secondary_colour:
         colour_prop = "Gradient"
         if role.tertiary_colour:
             colour_value = str(role.colour) + "–" + str(role.secondary_colour) + "–" + str(role.tertiary_colour)

--- a/bot/modules/Info/info_cmds.py
+++ b/bot/modules/Info/info_cmds.py
@@ -85,7 +85,7 @@ async def cmd_roleinfo(ctx: Context):
     # Handle roles with gradients
     if role.secondary_colour:
         colour_prop = "Gradient"
-        if role.tertiary_color:
+        if role.tertiary_colour:
             colour_value = str(role.colour) + "–" + str(role.secondary_colour) + "–" + str(role.tertiary_colour)
         else:
             colour_value = str(role.colour) + "–" + str(role.secondary_colour)


### PR DESCRIPTION
**Fixes [this issue](https://github.com/JetRaidz/paradox/issues/19) from [this thread](https://discord.com/channels/411477843969703936/1439192530301358101).**

Adds gradient Role support to command `roleinfo` through a role gradient handling block. Alters the value and prop lists.

_[Credits to the code provided by 0lante](https://discord.com/channels/411477843969703936/1439192530301358101/1439193194788290640)_