### PR TITLE
Add error message for command giveme when guild has no self roles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,20 @@
+---
+name: Bug Report
+about: Report an issue to be fixed
+title: "[Bug]"
+labels: bug
+assignees: ''
+
+---
+
+# Description
+Add a detailed description of what the issue is.
+
+# Expected Behaviour
+What were you expecting to happen?
+
+# Steps to Reproduce
+Provide clear steps to reproduce this bug, so it can be tested and fixed.
+
+# Additional Information
+Attach any supporting information that might help diagnose and fix this issue, such as screenshots.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest a new feature
+title: "[Request]"
+labels: enhancement
+assignees: ''
+
+---
+
+# Description
+Provide a detailed description of the feature you want added.
+
+# Scope
+Is this feature related to an existing feature, or is it completely new?
+
+# Additional Information
+Attach any supporting information that helps clarify this new feature, e.g. rough examples

--- a/.github/ISSUE_TEMPLATE/tweak.md
+++ b/.github/ISSUE_TEMPLATE/tweak.md
@@ -1,0 +1,17 @@
+---
+name: Tweak
+about: Minor changes to an existing feature
+title: "[Tweak]"
+labels: tweak
+assignees: ''
+
+---
+
+# Description
+Add a detailed description of what you want changed in an existing feature.
+
+# Affected Feature
+Which feature/function/utility etc. does this tweak apply to?
+
+# Additional Information
+Attach any supporting information that helps clarify the change you want, e.g. screenshots

--- a/bot/modules/User_Utils/selfrole_cmd.py
+++ b/bot/modules/User_Utils/selfrole_cmd.py
@@ -232,6 +232,10 @@ async def cmd_giveme(ctx: Context, flags):
                 "Please select the desired selfroles! "
                 "(Use `{}iamnot` to remove your current selfroles.)".format(ctx.best_prefix())
             )
+            if not selfroles:
+                return await ctx.error_reply(
+                    "No selfroles have been configured for this guild."
+                )
             select_from = [role for role in selfroles if role not in ctx.author.roles]
             if not select_from:
                 return await ctx.error_reply(


### PR DESCRIPTION
**Fixes issue #23 from [this thread](https://discord.com/channels/411477843969703936/1458801285443752061).**

Adds an `if not selfroles` block under `if add_alias` to prevent the misleading message displayed when trying to add a role to yourself when no guild selfroles exist:

> ``"You have all the selfroles! (Use `,iamnot` to remove them)."``
to
> `"No selfroles have been configured for this guild."`

<img width="930" height="676" alt="IMG_2938" src="https://github.com/user-attachments/assets/ab67228a-321f-4aac-9b47-0816deea49ee" />