### PR TITLE
fix: correct 'formtat' to 'format' typo in db_testor.py

### DIFF
--- a/data/scripts/db_testor.py
+++ b/data/scripts/db_testor.py
@@ -98,7 +98,7 @@ async def main():
 
     response = await data_noapp.users.find("property1", fakedata2, read=True)
     if response != []:
-        print("ISSUE: Got unexpected non-empty response from find, response\n{}".formtat(response))
+        print("ISSUE: Got unexpected non-empty response from find, response\n{}".format(response))
 
     # Test find not empty
     print("Testing finding non-empty values in user data")


### PR DESCRIPTION
Fixes issue #34 — corrects 'formtat' to 'format' typo in data/scripts/db_testor.py line 101.

**Change:** .format(response) (was .formtat(response))

**Note:** This is a Python string formatting error in a test script.